### PR TITLE
Feat/add dependabot python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -15,4 +19,8 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
 


### PR DESCRIPTION
## Add Dependabot updates for Python #32

### Description
Extend Dependabot configuration to automatically check and update Python dependencies alongside the existing GitHub Actions updates, with enhanced commit message customization.

### Changes
- ✅ Add `pip` package ecosystem to Dependabot configuration
- ✅ Enable weekly dependency update checks for Python packages
- ✅ Add custom commit message prefixes for better organization:
  - `ci:` prefix for GitHub Actions updates
  - `deps:` prefix for Python dependency updates
- ✅ Include scope in commit messages for clarity
- ✅ Complements existing GitHub Actions Dependabot setup from #31

### Benefits
- Keeps Python dependencies (requests, Jinja2, flake8, pylint, yamllint) up-to-date automatically
- Improves security by catching vulnerability patches quickly
- Better PR organization with semantic commit message prefixes
- Reduces manual dependency management overhead

### Files Changed
- `.github/dependabot.yml`

### Related Issue
Closes #32