### PR TITLE
Removed text from desktop #189

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -1062,7 +1062,9 @@ function showLoadingState() {
   const loadingState = document.getElementById('loadingState');
   const resultsInfo = document.getElementById('resultsInfo');
 
-
+  [loadingState].forEach(
+    (el) => el && (el.style.display = 'flex'),
+  );
   if (resultsInfo) resultsInfo.style.display = 'none';
 }
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -143,8 +143,6 @@ async function fetchAndPrepareUsers() {
     isDataLoaded = true;
     const total = allUsers.length;
     document.getElementById('totalCount').textContent = total.toLocaleString();
-    document.getElementById('totalCountDesktop').textContent =
-      total.toLocaleString();
   } catch (err) {
     console.error(err);
     const loadingStates = document.querySelectorAll('.loading-state');
@@ -995,10 +993,6 @@ function updateCounts(sortedUsers) {
   document.getElementById('totalCount').textContent =
     totalCount.toLocaleString();
 
-  document.getElementById('visibleCountDesktop').textContent =
-    visibleCount.toLocaleString();
-  document.getElementById('totalCountDesktop').textContent =
-    totalCount.toLocaleString();
 }
 
 /**
@@ -1012,21 +1006,15 @@ function updateResultsMessage(sortedUsers) {
   const resultsFound = document.getElementById('resultsFound');
   const noResults = document.getElementById('noResults');
 
-  const resultsFoundDesktop = document.getElementById('resultsFoundDesktop');
-  const noResultsDesktop = document.getElementById('noResultsDesktop');
 
   // TODO
   // if (totalCount === 0) {}
   if (visibleCount === 0) {
     if (resultsFound) resultsFound.style.display = 'none';
     if (noResults) noResults.style.display = 'block';
-    if (resultsFoundDesktop) resultsFoundDesktop.style.display = 'none';
-    if (noResultsDesktop) noResultsDesktop.style.display = 'block';
   } else {
     if (resultsFound) resultsFound.style.display = 'block';
     if (noResults) noResults.style.display = 'none';
-    if (resultsFoundDesktop) resultsFoundDesktop.style.display = 'block';
-    if (noResultsDesktop) noResultsDesktop.style.display = 'none';
   }
 }
 
@@ -1072,15 +1060,10 @@ function resetFilters() {
  */
 function showLoadingState() {
   const loadingState = document.getElementById('loadingState');
-  const loadingStateDesktop = document.getElementById('loadingStateDesktop');
   const resultsInfo = document.getElementById('resultsInfo');
-  const resultsInfoDesktop = document.getElementById('resultsInfoDesktop');
 
-  [loadingState, loadingStateDesktop].forEach(
-    (el) => el && (el.style.display = 'flex'),
-  );
+
   if (resultsInfo) resultsInfo.style.display = 'none';
-  if (resultsInfoDesktop) resultsInfoDesktop.style.display = 'none';
 }
 
 /**
@@ -1088,12 +1071,8 @@ function showLoadingState() {
  */
 function hideLoadingState() {
   const loadingState = document.getElementById('loadingState');
-  const loadingStateDesktop = document.getElementById('loadingStateDesktop');
   const resultsInfo = document.getElementById('resultsInfo');
-  const resultsInfoDesktop = document.getElementById('resultsInfoDesktop');
 
   if (loadingState) loadingState.style.display = 'none';
-  if (loadingStateDesktop) loadingStateDesktop.style.display = 'none';
   if (resultsInfo) resultsInfo.style.display = 'block';
-  if (resultsInfoDesktop) resultsInfoDesktop.style.display = 'block';
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -316,20 +316,6 @@ h1 {
   display: none;
 }
 
-.results-info-desktop {
-  text-align: center;
-  color: #666;
-  font-size: 13px;
-}
-
-.results-info-desktop strong {
-  font-weight: 600;
-}
-
-#resultsFoundDesktop {
-  display: none;
-}
-
 /* ============================================================================ */
 /* LOADING STATE */
 /* ============================================================================ */
@@ -351,8 +337,7 @@ h1 {
   }
 }
 
-#loadingState,
-#loadingStateDesktop {
+#loadingState{
   position: fixed;
   top: 0;
   left: 0;
@@ -863,10 +848,6 @@ footer {
   h1 {
     font-size: 1.8rem;
     margin: 20px 0;
-  }
-
-  .results-info-desktop {
-    display: none;
   }
 }
 

--- a/layouts/layout.html
+++ b/layouts/layout.html
@@ -438,26 +438,6 @@
           </div>
         </section>
 
-        <div
-          class="results-info-desktop loading-state"
-          id="loadingStateDesktop"
-          style="display: none"
-        >
-          <div class="loading-spinner"></div>
-          <p>Loading developers...</p>
-          <p class="error-message" style="display: none"></p>
-        </div>
-
-        <div class="results-info-desktop" id="resultsInfoDesktop">
-          <div id="resultsFoundDesktop">
-            Showing <strong id="visibleCountDesktop">0</strong> of
-            <strong id="totalCountDesktop">0</strong> developers
-          </div>
-          <div id="noResultsDesktop" style="display: none">
-            <strong>No developers found</strong> matching your filters.
-          </div>
-        </div>
-
         <div class="grid" id="grid"></div>
       </main>
     </div>


### PR DESCRIPTION
This PR fixes #189 
 
As requested, I have removed  "Showing X of Y developers" text from top of the page in desktop. 

**Changes included**

- Removed the desktop-specific results info UI from the HTML layout.
- Updated the corresponding JavaScript logic to ensure no references remain to the removed desktop elements
- Cleaned up corresponding styling part which was not required
- All pre - commits checks passed successfully

Screenshot is attached

<img width="1893" height="956" alt="Screenshot 2025-12-26 234155" src="https://github.com/user-attachments/assets/0ade6d7e-1710-41b9-aa0e-50b9407c57cb" />
