### PR TITLE
chore: add docs optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ name = "github-faces"
 version = "0.1.0"
 dependencies = ["requests>=2.33.1", "Jinja2>=3.1.6"]
 
-[project.optional-dependencies]
-docs = ["Sphinx>=8.2.3"]
+[tool.poetry.group.docs.dependencies]
+Sphinx = ">=8.2.3"
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ name = "github-faces"
 version = "0.1.0"
 dependencies = ["requests>=2.33.1", "Jinja2>=3.1.6"]
 
+[project.optional-dependencies]
+docs = ["Sphinx>=8.2.3"]
+
 [tool.poetry.dev-dependencies]
 flake8 = "*"
 pylint = "*"


### PR DESCRIPTION
## Summary
- Move the docs build dependency into `pyproject.toml` as a `docs` optional dependency group.
- Keeps the Sphinx docs requirement discoverable/installable from the project metadata instead of a separate requirements file.

## Validation
- Parsed `pyproject.toml` with `tomli` and verified `project.optional-dependencies.docs` is present.
- Ran `git diff --check`.

Resolves #192