### PR TITLE
fix: format YAML files for prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,29 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
     commit-message:
-      prefix: 'ci'
-      include: 'scope'
+      prefix: "ci"
+      include: "scope"
     groups:
       github-actions:
         patterns:
-          - '*'
+          - "*"
     cooldown:
       default-days: 7
-  - package-ecosystem: 'pip'
-    directory: '/'
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
     commit-message:
-      prefix: 'deps'
-      include: 'scope'
+      prefix: "deps"
+      include: "scope"
     groups:
       python-dependencies:
         patterns:
-          - '*'
+          - "*"
     cooldown:
       default-days: 7

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,16 +10,16 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: 'CodeQL'
+name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: ["master"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: ["master"]
   schedule:
-    - cron: '26 19 * * 1'
+    - cron: "26 19 * * 1"
 
 permissions:
   contents: read
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript', 'python']
+        language: ["javascript", "python"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed


### PR DESCRIPTION
## Summary
Fixes #219

## Changes
- reformatted `.github/workflows/codeql-analysis.yml` to satisfy Prettier's YAML style
- reformatted `.github/dependabot.yml` to satisfy the same YAML_PRETTIER rule
- kept the configuration semantics unchanged while fixing the linter failure

## Testing
- Parsed the edited YAML files with `python3` + `yaml.safe_load`
- Confirmed the repo has no local `package.json`, so there is no narrower project test suite to run here

## Bounty
This PR addresses the bounty on issue #219.
